### PR TITLE
実行用ノートブックファイルを追加

### DIFF
--- a/WallClassification.ipynb
+++ b/WallClassification.ipynb
@@ -1,0 +1,160 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# 今回使用するレポジトリをGoogle Colabの環境にクローン\n",
+    "!git clone https://github.com/s0yamazaki/WallClassification.git"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "autoexec": {
+      "startup": false,
+      "wait_interval": 0
+     }
+    },
+    "colab_type": "code",
+    "collapsed": true,
+    "id": "ximz5pRYgpTL"
+   },
+   "outputs": [],
+   "source": [
+    "# メインスクリプトの格納ディレクトリに移動\n",
+    "os.chdir('WallClassification')\n",
+    "!ls"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "autoexec": {
+      "startup": false,
+      "wait_interval": 0
+     },
+     "base_uri": "https://localhost:8080/",
+     "height": 221
+    },
+    "colab_type": "code",
+    "collapsed": true,
+    "executionInfo": {
+     "elapsed": 3138,
+     "status": "ok",
+     "timestamp": 1530577533345,
+     "user": {
+      "displayName": "金井伸也",
+      "photoUrl": "//lh6.googleusercontent.com/-woeiqb0cowI/AAAAAAAAAAI/AAAAAAAAADQ/uQEtD8TN81Y/s50-c-k-no/photo.jpg",
+      "userId": "114517870211293052336"
+     },
+     "user_tz": -540
+    },
+    "id": "J4_BAasChLtT",
+    "outputId": "b0a87fa6-5048-4c46-ba80-e22808f5700d"
+   },
+   "outputs": [],
+   "source": [
+    "# メインスクリプトである`model.py`の使用方法を表示\n",
+    "!python model.py -h"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "autoexec": {
+      "startup": false,
+      "wait_interval": 0
+     },
+     "base_uri": "https://localhost:8080/",
+     "height": 1312
+    },
+    "colab_type": "code",
+    "collapsed": true,
+    "executionInfo": {
+     "elapsed": 2249936,
+     "status": "ok",
+     "timestamp": 1530585600643,
+     "user": {
+      "displayName": "金井伸也",
+      "photoUrl": "//lh6.googleusercontent.com/-woeiqb0cowI/AAAAAAAAAAI/AAAAAAAAADQ/uQEtD8TN81Y/s50-c-k-no/photo.jpg",
+      "userId": "114517870211293052336"
+     },
+     "user_tz": -540
+    },
+    "id": "YT265URr38GV",
+    "outputId": "36d66d3d-d651-4175-e8a3-1173afe03b42"
+   },
+   "outputs": [],
+   "source": [
+    "# メインスクリプトを実行\n",
+    "!python model.py testmodel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# 生成されたファイルとディレクトリを表示\n",
+    "print('* カレントディレクトリ')\n",
+    "!ls .\n",
+    "print('\\n* testmodel ディレクトリ')\n",
+    "!ls ./testmodel"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "default_view": {},
+   "name": "WallClassification.ipynb",
+   "provenance": [],
+   "version": "0.3.2",
+   "views": {}
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
スクリプト実行用のノートブックファイル「WallClassificatin.ipynb」を追加しました。
出力は全て消してあります。
↓のGITHUBのタブにレポジトリのURLを入力し、追加したノートブックを開いて実行できます。
https://colab.research.google.com/
4epochくらい回して、挙動が問題ないことを確認しました。